### PR TITLE
Remove Django<3 install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         '': ['*.po', '*.mo'],
     },
     install_requires=[
-        'django>=1.11.29,<3.0',
+        'django>=1.11.29',
     ],
     keywords='django choices models enum',
     classifiers=[


### PR DESCRIPTION
Django 3.0 support was mentioned in 9237ad4c46bdd4cca3a6fde7d9201cc46a29e0a1, but still setup.py forces the downgrade